### PR TITLE
Ignore dev/test groups for Ruby

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,6 @@
 steps:
   - label: 'Ruby'
+    if: build.env("FULL_BUILD") == "true"
     timeout_in_minutes: 240
     plugins:
       - docker-compose#v3.7.0:
@@ -9,7 +10,9 @@ steps:
     artifact_paths:
       - build/*.txt
       - reports/*.html
+
   - label: 'PHP'
+    if: build.env("FULL_BUILD") == "true"
     timeout_in_minutes: 240
     plugins:
       - docker-compose#v3.7.0:
@@ -19,7 +22,9 @@ steps:
     artifact_paths:
       - build/*.txt
       - reports/*.html
+
   - label: 'JS'
+    if: build.env("FULL_BUILD") == "true"
     timeout_in_minutes: 240
     plugins:
       - docker-compose#v3.7.0:
@@ -29,7 +34,9 @@ steps:
     artifact_paths:
       - build/*.txt
       - reports/*.html
+
   - label: 'Java'
+    if: build.env("FULL_BUILD") == "true"
     timeout_in_minutes: 240
     plugins:
       - docker-compose#v3.7.0:
@@ -39,7 +46,9 @@ steps:
     artifact_paths:
       - build/*.txt
       - reports/*.html
+
   - label: 'Python'
+    if: build.env("FULL_BUILD") == "true"
     timeout_in_minutes: 240
     plugins:
       - docker-compose#v3.7.0:

--- a/config/decision_files/bugsnag-ruby.yml
+++ b/config/decision_files/bugsnag-ruby.yml
@@ -1,7 +1,24 @@
-- - :approve
-  - power_assert
-  - :who: Tom
-    :why: "Not detected by tool - BSD 2-clause license (https://github.com/k-tsj/power_assert/blob/v1.1.3/COPYING)"
-    :versions: ['1.1.3']
-    :when: 2019-12-09 15:00:00.000000000 Z
-
+- - :ignore_group
+  - sidekiq
+  - :who: Steve
+    :why: Group does not include runtime dependencies of the notifier
+    :versions: []
+    :when: 2021-04-14 17:34:34.662850000 Z
+- - :ignore_group
+  - test
+  - :who: Steve
+    :why: Group does not include runtime dependencies of the notifier
+    :versions: []
+    :when: 2021-04-14 17:34:35.248600000 Z
+- - :ignore_group
+  - coverage
+  - :who: Steve
+    :why: Group does not include runtime dependencies of the notifier
+    :versions: []
+    :when: 2021-04-14 17:34:35.843103000 Z
+- - :ignore_group
+  - rubocop
+  - :who: Steve
+    :why: Group does not include runtime dependencies of the notifier
+    :versions: []
+    :when: 2021-04-14 17:34:36.423089000 Z


### PR DESCRIPTION
We are using this repository as the central point for license_finder decisions in the notifier repositories.  Decision files here are dynamically pulled in by steps in the notifier CI pipelines, ensuring that infringements are blocked at source.

The additions in this PR are specific to `bugsnag-ruby` and filter out dependencies present in the `Gemfile` that are not runtime dependencies of the notifier itself.

I've also updated the Buildlkite pipeline for this repo so that the steps are only run when a full build is scheduled.  (It's not the best way of doing that, but it's the quickest to implement).