### PR TITLE
Ignore ruby test and development groups

### DIFF
--- a/config/decision_files/common-ruby.yml
+++ b/config/decision_files/common-ruby.yml
@@ -1,0 +1,12 @@
+- - :ignore_group
+  - development
+  - :who: Steve
+    :why: Group does not include runtime dependencies of the notifier
+    :versions: []
+    :when: 2021-04-19 17:34:35.248600000 Z
+- - :ignore_group
+  - test
+  - :who: Steve
+    :why: Group does not include runtime dependencies of the notifier
+    :versions: []
+    :when: 2021-04-19 17:34:35.248600000 Z


### PR DESCRIPTION
Allows our Ruby-based repos to ignore `test` and `development` groups in `Gemfile`s for the purposes of license auditing.