### PR TITLE
Updates for JavaScript

### DIFF
--- a/config/decision_files/bugsnag-js.yml
+++ b/config/decision_files/bugsnag-js.yml
@@ -1,0 +1,6 @@
+- - :approve
+  - "consola"
+  - :who: Steve
+    :why: "MIT licensed, just no LICENSE file on Github"
+    :versions: ['2.15.0']
+    :when: 2019-''07-02 07:23:26.514774000 Z

--- a/config/decision_files/common-js.yml
+++ b/config/decision_files/common-js.yml
@@ -1,0 +1,6 @@
+- - :ignore_group
+  - devDependencies
+  - :who: Steve
+    :why: Group does not include runtime dependencies of the notifier
+    :versions: []
+    :when: 2021-04-19 17:34:35.248600000 Z


### PR DESCRIPTION
- Ignore all `devDependencies`
- Approve Consola, which is MIT (stated in README and on NPM) but has no LICENSE in github.