### PR TITLE
Add approval for Android-gradle-plugin dependencies not detected by tool

### DIFF
--- a/config/decision_files/bugsnag-android-gradle-plugin.yml
+++ b/config/decision_files/bugsnag-android-gradle-plugin.yml
@@ -1,0 +1,6 @@
+- - :approve
+  - okio
+  - :who: Alex
+    :why: "Not detected by tool - Apache License 2.0 (https://github.com/square/okio/blob/parent-2.7.0/LICENSE.txt)"
+    :versions: ['2.7.0']
+    :when: 2021-04-29 17:07:00.000000000 Z


### PR DESCRIPTION
Adds a decision file for the android-gradle-plugin approving [Square/OKIO](https://github.com/square/okio) as it's `LICENSE.txt` is picked up by the license_finder tool.